### PR TITLE
Fix for IE11

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,27 +3,26 @@
   <head>
     <meta charset="utf-8"/>
     <title>Web Chat: Markdown</title>
-    
+
     <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
-    <script src="https://cdn.botframework.com/botframework-webchat/4.2.1-master.14eebbb/webchat-es5.js"></script>
+    <script src="https://unpkg.com/core-js@2.6.3/client/core.min.js"></script>
+    <script src="https://unpkg.com/whatwg-fetch@3.0.0/dist/fetch.umd.js"></script>
     <script src="https://unpkg.com/marked@0.6.0/lib/marked.js"></script>
     <script src="https://unpkg.com/sanitize-html@1.20.0/dist/sanitize-html.min.js"></script>
     <link rel="stylesheet" href="index.css">
-    
+
   </head>
   <body>
-    <div class="wc-header"<span> チャットボット </span></div>
+    <div class="wc-header"><span> チャットボット </span></div>
     <div id="webchat" role="main"></div>
-    
-    <script>
 
-      (async function(){
-        fetch('https://directline.botframework.com/v3/directline/tokens/generate', { 
-                                  method: 'POST',
-                                  headers:{
-                                    'Authorization': 'Bearer YOUR_SECRET_KEY'
-                                    } 
-                                  })
+    <script>
+      fetch('https://directline.botframework.com/v3/directline/tokens/generate', {
+        method: 'POST',
+        headers:{
+          'Authorization': 'Bearer YOUR_SECRET_KEY'
+        }
+      })
         .then(function (res) { return res.json(); })
         .then(function (json) {
           const token = json.token;
@@ -82,14 +81,18 @@
           });
 
           //フォントの設定
-          styleSet.textContent = { ...styleSet.textContent,
-          fontFamily: '\'Comic Sans MS\', \'Arial\', sans-serif',
-          fontWeight: 'bold',
-          };
+          styleSet.textContent = Object.assign(
+            {},
+            styleSet.textContent,
+            {
+              fontFamily: '\'Comic Sans MS\', \'Arial\', sans-serif',
+              fontWeight: 'bold',
+            }
+          );
 
           window.WebChat.renderWebChat({
             directLine: window.WebChat.createDirectLine({ token: token }),
-            styleSet,
+            styleSet: styleSet,
             renderMarkdown: function (markdown) {
               const html = window.marked(markdown);
 
@@ -98,10 +101,7 @@
           }, document.getElementById('webchat'));
 
           document.querySelector('#webchat > *').focus();
-        })
-
-      })().catch(err => console.error(err));
-
+        });
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,9 +4,7 @@
     <meta charset="utf-8"/>
     <title>Web Chat: Markdown</title>
 
-    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat.js"></script>
-    <script src="https://unpkg.com/core-js@2.6.3/client/core.min.js"></script>
-    <script src="https://unpkg.com/whatwg-fetch@3.0.0/dist/fetch.umd.js"></script>
+    <script src="https://cdn.botframework.com/botframework-webchat/master/webchat-es5.js"></script>
     <script src="https://unpkg.com/marked@0.6.0/lib/marked.js"></script>
     <script src="https://unpkg.com/sanitize-html@1.20.0/dist/sanitize-html.min.js"></script>
     <link rel="stylesheet" href="index.css">


### PR DESCRIPTION
Changes:
- `fetch` is not supported on IE11, requires polyfill
   - `webchat-es5.js` includes some polyfill to make Web Chat works with IE11, and coincidentally, it also include `fetch`
- Rest/spread operator is not supported on IE11
   - Use `object.assign` instead
   - Replace `styleSet` with `styleSet: styleSet` on the props